### PR TITLE
Support for post-v6.43 versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## 1.2 - 2020-05-13
+### Changed
+- **BREAKING**: default login method is the post-v6.43 login method, see 
+https://wiki.mikrotik.com/wiki/Manual:API#Initial_login

--- a/README.md
+++ b/README.md
@@ -52,9 +52,13 @@ In [5]:
 ```
 
 ### How to use non-default (8728) API port for login, such as 9999
- 
+
+```python
 routeros = login('user', 'password', '10.1.0.1', 9999)
+```
 
 ### How to use pre-v6.43 login method
 
+```python
 routeros = login('user', 'password', '10.1.0.1', 8728, True)
+```

--- a/README.md
+++ b/README.md
@@ -50,3 +50,11 @@ In [4]: routeros.close()
 In [5]: 
 
 ```
+
+### How to use non-default (8728) API port for login, such as 9999
+ 
+routeros = login('user', 'password', '10.1.0.1', 9999)
+
+### How to use pre-v6.43 login method
+
+routeros = login('user', 'password', '10.1.0.1', 8728, True)

--- a/routeros/__init__.py
+++ b/routeros/__init__.py
@@ -8,7 +8,7 @@ from routeros.utils import API, Socket
 from routeros.api import RouterOS
 
 
-def login(username, password, host, port=8728):
+def login(username, password, host, port=8728, use_old_login_method=False):
     """
     Connect and login to routeros device.
     Upon success return a RouterOS class.
@@ -23,10 +23,13 @@ def login(username, password, host, port=8728):
     routeros = RouterOS(protocol=protocol)
 
     try:
-        sentence = routeros('/login')
-        token = sentence[0]['ret']
-        encoded = encode_password(token, password)
-        routeros('/login', **{'name': username, 'response': encoded})
+        if use_old_login_method:                # Login method pre-v6.43
+            sentence = routeros('/login')
+            token = sentence[0]['ret']
+            encoded = encode_password(token, password)
+            routeros('/login', **{'name': username, 'response': encoded})
+        else:                                   # Login method post-v6.43
+            routeros('/login', **{'name': username, 'password': password})
     except (ConnectionError, TrapError, FatalError):
         transport.close()
         raise

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@ from distutils.core import setup
 setup(
   name='routeros',
   packages=['routeros'],
-  version='1.1',
+  version='1.2',
   description='Implementation of Mikrotik API',
   license='MIT',
   author='Ramiro Tician',
   author_email='ramirotician@gmail.com',
   url='https://github.com/rtician/routeros',
-  download_url='https://github.com/rtician/routeros/archive/v1.1.tar.gz',
+  download_url='https://github.com/rtician/routeros/archive/v1.2.tar.gz',
   keywords=['mikrotik', 'routeros', 'api'],
   classifiers=[
       'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This change adds support for post-v6.43 login method and changes the default login method to post-v6.43 login method with the ability to specify pre-v6.43 login method if needed.
**This is a breaking change for users of pre-v6.43 devices!**
post-v6.43 login method should be a default one, considering that all new users will most probably have post-v6.43 version installed on their new mikrotik devices and users of pre-v6.43 version should upgrade to the latest version available.
