### PR TITLE
Fix short reads

### DIFF
--- a/routeros/utils.py
+++ b/routeros/utils.py
@@ -28,15 +28,20 @@ class Socket:
         :param length: length to read on socket.
         :return: data (string) received from socket.
         """
-        try:
-            data = self.sock.recv(length)
-            if not data:
-                raise ConnectionError('Connection was closed.')
-            return data
-        except SOCKET_TIMEOUT as exc:
-            raise ConnectionError('Socket timed out. ' + str(exc))
-        except SOCKET_ERROR as exc:
-            raise ConnectionError('Failed to read from socket. {0}'.format(exc))
+        data = b''
+        while length > 0:
+            try:
+                read = self.sock.recv(length)
+                if not read:
+                    raise ConnectionError('Connection was closed.')
+                length -= len(read)
+                data += read
+            except SOCKET_TIMEOUT as exc:
+                raise ConnectionError('Socket timed out. ' + str(exc))
+            except SOCKET_ERROR as exc:
+                raise ConnectionError('Failed to read from socket. {0}'.format(exc))
+
+        return data
 
     def close(self):
         """


### PR DESCRIPTION
We’ve seen random “Socket timed out” errors and this was the cause. The code was assuming that `recv()` returns *exactly* `length` bytes, but it returns *at most* `length` bytes. So things like this were possible:

1.  recv(1) reads from the socket to retrieve the length of the next word.
2.  Let’s say the response is `16`, so we want to read 16 bytes next.
3.  Every now and then (or if your connection is slow, because you’re managing a switch remotely over a VPN), `recv(16)` will only return, say, 14 bytes.
4.  The code didn’t cope with that and assumed that that’s the complete word. So the next iteration does a `recv(1)` again and that will now return *a part of the previous word*. Everything goes haywire from here on.

I *believe* this could also fix #3, but I haven’t fully investigated this (I’ve only investigated the socket timeouts). Let’s just say: I haven’t seen instances of #3 happening anymore since I fixed short reads.